### PR TITLE
Update Readme.md - Fixed broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ AngularJS Module. that integrate cryptography functionality offers from the [cry
 
 #install(manual)
 
-* download [angular-hmac-sha512.js file](https://github.com/diablofong/angular-hmac-sha512/blob/master/src/angular-hmac-sha512.js)
+* download [angular-hmac-sha512.js file](https://github.com/diablofong/angular-hmac-sha512/blob/master/angular-hmac-sha512.js)
 * added javascript file to your app html file
 
 ```html


### PR DESCRIPTION
I don't know the history of this project. But the link is broken, it tries to end on this page : 

https://github.com/diablofong/angular-hmac-sha512/blob/master/src/angular-hmac-sha512.js

but there is no /src/ in master. The link became 

https://github.com/diablofong/angular-hmac-sha512/blob/master/angular-hmac-sha512.js
